### PR TITLE
Add Deno runtime to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 WORKDIR /app
 
 RUN pip install --no-cache-dir -r requirements.txt
-RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache ffmpeg deno
 
 ENV PYTHON_BIN python3
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
## Summary
Added Deno as a system dependency to the Docker image alongside the existing FFmpeg installation.

## Changes
- Added `deno` to the Alpine Linux package installation command in the Dockerfile

## Details
The Deno runtime is now installed during the Docker image build process via `apk add`. This enables Deno-based scripts or tools to run within the containerized application environment.

https://claude.ai/code/session_01HE6kW7CDgf3hKFBPS1zJvZ