### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+### Added
+- Install `deno` in the container so yt-dlp can run YouTube's JS extractor.
+
+### Changed
+- Update `python-telegram-bot` to 22.7.
+- Update `actions/checkout` to v6 and `docker/login-action` to v4 in workflows.
+
 ## [0.6.4] - 2024-06-10
 ### Changed
 - Update yt-dlp to nightly versions to better support changes in video sources.
@@ -76,7 +84,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Basic url -> video functionality
 
 
-[Unreleased]: https://github.com/classabbyamp/vidifierbot/compare/v0.6.3...HEAD
+[Unreleased]: https://github.com/cschmittiey/vidifierbot/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/cschmittiey/vidifierbot/releases/tag/v0.7.0
+[0.6.4]: https://github.com/cschmittiey/vidifierbot/releases/tag/v0.6.4
 [0.6.3]: https://github.com/classabbyamp/vidifierbot/releases/tag/v0.6.3
 [0.6.2]: https://github.com/classabbyamp/vidifierbot/releases/tag/v0.6.2
 [0.6.1]: https://github.com/classabbyamp/vidifierbot/releases/tag/v0.6.1


### PR DESCRIPTION
## Summary
- Add `0.7.0` changelog entry covering the deno install, PTB 22.7 upgrade, and Actions bumps merged from #13, #15, #16, #17
- Refresh changelog link URLs to point at `cschmittiey/vidifierbot` going forward

## Test plan
- [ ] Merge this PR
- [ ] Push the `v0.7.0` tag on master to trigger release + docker workflows
- [ ] Confirm GitHub release is created and `ghcr.io/cschmittiey/vidifierbot:v0.7.0` (+ `:latest`) image is published

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE6kW7CDgf3hKFBPS1zJvZ)_